### PR TITLE
feat: adversary and environment form UX improvements

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -74,6 +74,32 @@
     .form-group select {
         width: 100%;
     }
+
+    .dht-form-divider {
+        margin: 1.5rem 0 0.25rem;
+        border: none;
+        border-top: 1px solid var(--background-modifier-border);
+    }
+
+    .dht-form-section-heading {
+        margin: 0 0 1rem;
+        font-size: var(--font-small);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-muted);
+    }
+
+    .dht-form-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+        margin: 1.5rem 0;
+
+        .form-group {
+            min-width: unset;
+            margin: 0;
+        }
+    }
 }
 
 

--- a/src/view/AdversaryForm.svelte
+++ b/src/view/AdversaryForm.svelte
@@ -37,7 +37,7 @@
       console.log("setting id", id);
       adversary.id = id;
     }
-    
+
     let adversaryState = $state(adversary);
 
     export interface AdversaryErrorProps {
@@ -60,6 +60,7 @@
     };
 
     let errors: AdversaryErrorProps = $state({})
+    let touched: Partial<Record<keyof AdversaryErrorProps, boolean>> = $state({});
 
     let adversaryTypes: string[] = [
         "Bruiser",
@@ -94,10 +95,10 @@
 
     let thresholds: string = $derived.by(() => {
         return `${major_threshold ?? "-"}/${severe_threshold ?? "-"}`;
-    }) 
+    })
 
     _plugin.set(plugin);
-    
+
     $effect(() => {
       if (update) {
         if (required(adversaryState.name)) {
@@ -116,7 +117,6 @@
         }
       }
     });
-
 
     $effect(() => {
       if (required(adversaryState.text)) {
@@ -198,12 +198,16 @@
       }
     });
 
-    let features: { 
+    let features: {
       name?: string,
       text?: string,
       errors: {
         name?: string
         text?: string,
+      },
+      touched: {
+        name?: boolean,
+        text?: boolean,
       }
     }[] = $state([]);
 
@@ -212,7 +216,8 @@
         features.push({
           name: feat.name,
           text: feat.text,
-          errors: {}
+          errors: {},
+          touched: {}
         });
       })
     }
@@ -221,7 +226,8 @@
       features.push({
         name: "",
         text: "",
-        errors: {}
+        errors: {},
+        touched: {}
       })
     }
 
@@ -241,23 +247,27 @@
       })
     })
 
-    let experiences: { 
+    let experiences: {
       text?: string,
       value: number,
       errors: {
         text?: string,
         value?: string
+      },
+      touched: {
+        text?: boolean,
+        value?: boolean,
       }
     }[] = $state([]);
 
     if (adversary.experience) {
       adversary.experience.split(', ').forEach(exp => {
-        experiences.push({ text: exp.split(' +')[0], value: Number(exp.split(' +')[1]), errors: {}});
+        experiences.push({ text: exp.split(' +')[0], value: Number(exp.split(' +')[1]), errors: {}, touched: {}});
       })
     }
 
     const addExperience = () => {
-      experiences.push({ value: 2, errors: {}});
+      experiences.push({ value: 2, errors: {}, touched: {}});
     }
 
     $effect(() => {
@@ -297,7 +307,7 @@
         }
     }
 
-    const valid = $derived.by(() => {
+    const hasErrors = $derived.by(() => {
       return Object.values(errors).some(val => typeof val === 'string');
     })
 
@@ -319,9 +329,9 @@
     placeholder?: string
   })}
     <div class="form-group">
-      <label for={label} class={errors[errorKey] && "text-destructive"}>{label}</label>
-      <input {type} id={label} name={label} {placeholder} bind:value={adversaryState[value]} />
-      {#if errors[errorKey]}
+      <label for={label} class={errors[errorKey] && touched[errorKey] && "text-destructive"}>{label}</label>
+      <input {type} id={label} name={label} {placeholder} bind:value={adversaryState[value]} onblur={() => (touched[errorKey] = true)} />
+      {#if errors[errorKey] && touched[errorKey]}
         <p class="text-sm text-destructive">{errors[errorKey]}</p>
       {/if}
       <p class="text-xs text-muted-foreground">
@@ -332,6 +342,7 @@
 
 <div class="dht-adversary-form">
 
+    <!-- Identity -->
     {@render formInput({
       errorKey: "name",
       label: "Name",
@@ -341,34 +352,37 @@
       placeholder: "Bandit"
     })}
 
-    {#if adversaryState.alias}
-      {@render formInput({
-        errorKey: "alias",
-        label: "Alias",
-        type: "text",
-        value: "alias",
-        description: "The adversary's alias, used instead of name on save.",
-        placeholder: "Tim"
-      })}
-    {/if}
+    {@render formInput({
+      errorKey: "alias",
+      label: "Alias",
+      type: "text",
+      value: "alias",
+      description: "The adversary's alias, used instead of name on save.",
+      placeholder: "Tim"
+    })}
 
     <div class="form-group">
-      <label for="description" class={errors.text && "text-destructive"}>Description</label>
+      <label for="description" class={errors.text && touched.text && "text-destructive"}>Description</label>
       <textarea
         placeholder="What is the description of the adversary?"
         class="resize-none"
         id="description"
         name="description"
         bind:value={adversaryState.text}
+        onblur={() => (touched.text = true)}
       ></textarea>
       <p class="text-xs text-muted-foreground">
         This is the adversary's description
       </p>
-      {#if errors.text}
+      {#if errors.text && touched.text}
         <p class="text-xs text-destructive">{errors.text}</p>
       {/if}
     </div>
-    
+
+    <!-- Classification -->
+    <hr class="dht-form-divider" />
+    <h4 class="dht-form-section-heading">Classification</h4>
+
     {@render formInput({
         errorKey: "tier",
         label: "Tier",
@@ -377,22 +391,21 @@
         description: "The adversary's tier.",
         placeholder: "1"
       })}
-    
+
     <div class="form-group">
-      <label for="type" class={errors.adversaryType && "text-destructive"}>Adversary Type</label>
-      <select bind:value={adversaryState.adversaryType} name="type">
+      <label for="type" class={errors.adversaryType && touched.adversaryType && "text-destructive"}>Adversary Type</label>
+      <select bind:value={adversaryState.adversaryType} name="type" onblur={() => (touched.adversaryType = true)}>
         {#each adversaryTypes as advType}
-            <option value={advType} label={advType}></option>    
+            <option value={advType} label={advType}></option>
         {/each}
       </select>
       <p class="text-xs text-muted-foreground">
         Select the type of adversaryState.
       </p>
-      {#if errors.adversaryType}
+      {#if errors.adversaryType && touched.adversaryType}
           <p class="text-sm text-destructive">{errors.adversaryType}</p>
       {/if}
     </div>
-
 
     {@render formInput({
       errorKey: "motives_and_tactics",
@@ -404,161 +417,6 @@
     })}
 
     {@render formInput({
-      errorKey: "hp",
-      label: "HP",
-      type: "number",
-      value: "hp",
-      description: "The adversary's HP.",
-      placeholder: "1"
-    })}
-
-    {#if adversaryState.adversaryType === "Horde"}
-      <div class="form-group">
-        <label for="horde_count">#/HP</label>
-        <input type="number" id="horde_count" name="horde_count" placeholder="3" bind:value={adversaryState.horde_count} />
-        <p class="text-xs text-muted-foreground">
-          Number of units defeated per 1 HP of damage dealt.
-        </p>
-      </div>
-    {/if}
-
-    {@render formInput({
-      errorKey: "stress",
-      label: "Stress",
-      type: "number",
-      value: "stress",
-      description: "The adversary's Stress.",
-      placeholder: "1"
-    })}
-    
-    <div class="form-group">
-      <label for="major_threshold" class={errors.major_threshold && "text-destructive"}>Major Threshold</label>
-      <input type="number" id="major_threshold" name="major_threshold" placeholder="-" bind:value={major_threshold} />
-      {#if errors.major_threshold}
-        <p class="text-sm text-destructive">{errors.major_threshold}</p>
-      {/if}
-      <p class="text-xs text-muted-foreground">
-        This is the adversary's Major Armor Threshold
-      </p>
-    </div>
-
-    <div class="form-group">
-      <label for="severe_threshold" class={errors.severe_threshold && "text-destructive"}>Sever Threshold</label>
-      <input type="number" id="severe_threshold" name="severe_threshold" placeholder="-" bind:value={severe_threshold} />
-      {#if errors.severe_threshold}
-        <p class="text-sm text-destructive">{errors.severe_threshold}</p>
-      {/if}
-      <p class="text-xs text-muted-foreground">
-        This is the adversary's Sever Armor Threshold
-      </p>
-    </div>
-    
-    {@render formInput({
-      errorKey: "difficulty",
-      label: "Difficulty",
-      type: "number",
-      value: "difficulty",
-      description: "The adversary's difficulty.",
-      placeholder: "10"
-    })}
-    
-    {@render formInput({
-      errorKey: "atk",
-      label: "Attack Bonus",
-      type: "text",
-      value: "atk",
-      description: "The adversary's Attack Bonus.",
-      placeholder: "+1"
-    })}
-    
-    {@render formInput({
-      errorKey: "attack",
-      label: "Attack Name",
-      type: "text",
-      value: "attack",
-      description: "The adversary's Attack Name.",
-      placeholder: "Claw"
-    })}
-    
-    <div class="form-group">
-      <label for="range" class={errors.range && "text-destructive"}>Range</label>
-      <select bind:value={adversaryState.range} name="range">
-        {#each adversaryRanges as advRange}
-            <option value={advRange} label={advRange}></option>    
-        {/each}
-      </select>
-      <p class="text-xs text-muted-foreground">
-        This is the range of the adversary's basic attack.
-      </p>
-      {#if errors.range}
-          <p class="text-sm text-destructive">{errors.range}</p>
-      {/if}
-    </div>
-
-    {@render formInput({
-      errorKey: "damage",
-      label: "Damage Value",
-      type: "text",
-      value: "damage",
-      description: "The adversary's attack damage value.",
-      placeholder: "1d4+1 phys"
-    })}    
-    
-    <div class="form-group">
-      <label class="label-heading" for="experiences">Experiences</label>
-      <p class="text-xs text-muted-foreground">
-        These are the adversary's experiences.
-      </p>
-      {#each experiences as experience, i}
-        <div class="sub-group">
-          <div class="added-button">
-            <label for="experience-name" class={experience.errors.text && "text-destructive"}>Experience Text</label>
-            <button onclick={() => {
-              experiences.remove(experience);
-            }}>X</button>
-          </div>
-          <input type="text" name="experience-text" placeholder="Die to heroes" bind:value={experience.text} />
-          {#if experience.errors.text}
-            <p class="text-sm text-destructive">{experience.errors.text}</p>
-          {/if}
-          <label for="experience-value" class={experience.errors.value && "text-destructive"}>Experience Value</label>
-          <input type="number" name="experience-value" placeholder="2" bind:value={experience.value} />
-          {#if experience.errors.value}
-            <p class="text-sm text-destructive">{experience.errors.value}</p>
-          {/if}
-        </div>
-      {/each}
-      <button class="add-button" onclick={addExperience}>Add Experience</button>
-    </div>
-
-    <div class="form-group">
-      <label class="label-heading" for="features">Features</label>
-      <p class="text-xs text-muted-foreground">
-        These are the adversary's features.
-      </p>
-      {#each features as feature}
-        <div class="sub-group">
-          <div class="added-button">
-            <label for="feature-name" class={feature.errors.name && "text-destructive"}>Feature Name</label>
-            <button onclick={() => {
-              features.remove(feature);
-            }}>X</button>
-          </div>
-          <input type="text" name="feature-name" placeholder="Feature name here" bind:value={feature.name} />
-          <label for="feature-text" class={feature.errors.text && "text-destructive"}>Feature Text</label>
-          <input type="text" name="feature-text" placeholder="Feature text here" bind:value={feature.text} />
-          {#if feature.errors.name}
-            <p class="text-sm text-destructive">{feature.errors.name}</p>
-          {/if}
-          {#if feature.errors.text}
-            <p class="text-sm text-destructive">{feature.errors.text}</p>
-          {/if}
-        </div>
-      {/each}
-      <button class="add-button" onclick={addFeature}>Add Feature</button>
-    </div>
-
-    {@render formInput({
       errorKey: "source",
       label: "Source",
       type: "text",
@@ -567,5 +425,176 @@
       placeholder: "homebrew"
     })}
 
-    <button type="submit" onclick={onSubmit} disabled={valid}>Submit</button>
+    <!-- Combat Stats -->
+    <hr class="dht-form-divider" />
+    <h4 class="dht-form-section-heading">Combat Stats</h4>
+
+    <div class="dht-form-row">
+      <div class="form-group">
+        <label for="HP" class={errors.hp && touched.hp && "text-destructive"}>HP</label>
+        <input type="number" id="HP" name="HP" placeholder="1" bind:value={adversaryState.hp} onblur={() => (touched.hp = true)} />
+        {#if errors.hp && touched.hp}
+          <p class="text-sm text-destructive">{errors.hp}</p>
+        {/if}
+        <p class="text-xs text-muted-foreground">The adversary's HP.</p>
+        {#if adversaryState.adversaryType === "Horde"}
+          <label for="horde_count">#/HP</label>
+          <input type="number" id="horde_count" name="horde_count" placeholder="3" bind:value={adversaryState.horde_count} />
+          <p class="text-xs text-muted-foreground">
+            Number of units defeated per 1 HP of damage dealt.
+          </p>
+        {/if}
+      </div>
+
+      <div class="form-group">
+        <label for="Stress" class={errors.stress && touched.stress && "text-destructive"}>Stress</label>
+        <input type="number" id="Stress" name="Stress" placeholder="1" bind:value={adversaryState.stress} onblur={() => (touched.stress = true)} />
+        {#if errors.stress && touched.stress}
+          <p class="text-sm text-destructive">{errors.stress}</p>
+        {/if}
+        <p class="text-xs text-muted-foreground">The adversary's Stress.</p>
+      </div>
+    </div>
+
+    <div class="dht-form-row">
+      <div class="form-group">
+        <label for="major_threshold" class={errors.major_threshold && touched.major_threshold && "text-destructive"}>Major Threshold</label>
+        <input type="number" id="major_threshold" name="major_threshold" placeholder="-" bind:value={major_threshold} onblur={() => (touched.major_threshold = true)} />
+        {#if errors.major_threshold && touched.major_threshold}
+          <p class="text-sm text-destructive">{errors.major_threshold}</p>
+        {/if}
+        <p class="text-xs text-muted-foreground">
+          This is the adversary's Major Armor Threshold
+        </p>
+      </div>
+
+      <div class="form-group">
+        <label for="severe_threshold" class={errors.severe_threshold && touched.severe_threshold && "text-destructive"}>Severe Threshold</label>
+        <input type="number" id="severe_threshold" name="severe_threshold" placeholder="-" bind:value={severe_threshold} onblur={() => (touched.severe_threshold = true)} />
+        {#if errors.severe_threshold && touched.severe_threshold}
+          <p class="text-sm text-destructive">{errors.severe_threshold}</p>
+        {/if}
+        <p class="text-xs text-muted-foreground">
+          This is the adversary's Severe Armor Threshold
+        </p>
+      </div>
+    </div>
+
+    {@render formInput({
+      errorKey: "difficulty",
+      label: "Difficulty",
+      type: "number",
+      value: "difficulty",
+      description: "The adversary's difficulty.",
+      placeholder: "10"
+    })}
+
+    <!-- Attack -->
+    <hr class="dht-form-divider" />
+    <h4 class="dht-form-section-heading">Attack</h4>
+
+    {@render formInput({
+      errorKey: "atk",
+      label: "Attack Bonus",
+      type: "text",
+      value: "atk",
+      description: "The adversary's Attack Bonus.",
+      placeholder: "+1"
+    })}
+
+    <div class="dht-form-row">
+      {@render formInput({
+        errorKey: "attack",
+        label: "Attack Name",
+        type: "text",
+        value: "attack",
+        description: "The adversary's Attack Name.",
+        placeholder: "Claw"
+      })}
+      {@render formInput({
+        errorKey: "damage",
+        label: "Damage Value",
+        type: "text",
+        value: "damage",
+        description: "The adversary's attack damage value.",
+        placeholder: "1d4+1 phys"
+      })}
+    </div>
+
+    <div class="form-group">
+      <label for="range" class={errors.range && touched.range && "text-destructive"}>Range</label>
+      <select bind:value={adversaryState.range} name="range" onblur={() => (touched.range = true)}>
+        {#each adversaryRanges as advRange}
+            <option value={advRange} label={advRange}></option>
+        {/each}
+      </select>
+      <p class="text-xs text-muted-foreground">
+        This is the range of the adversary's basic attack.
+      </p>
+      {#if errors.range && touched.range}
+          <p class="text-sm text-destructive">{errors.range}</p>
+      {/if}
+    </div>
+
+    <!-- Experiences -->
+    <hr class="dht-form-divider" />
+    <h4 class="dht-form-section-heading">Experiences</h4>
+
+    <div class="form-group">
+      <p class="text-xs text-muted-foreground">
+        These are the adversary's experiences.
+      </p>
+      {#each experiences as experience, i}
+        <div class="sub-group">
+          <div class="added-button">
+            <label for="experience-name" class={experience.errors.text && experience.touched.text && "text-destructive"}>Experience Text</label>
+            <button onclick={() => {
+              experiences.remove(experience);
+            }}>X</button>
+          </div>
+          <input type="text" name="experience-text" placeholder="Die to heroes" bind:value={experience.text} onblur={() => (experience.touched.text = true)} />
+          {#if experience.errors.text && experience.touched.text}
+            <p class="text-sm text-destructive">{experience.errors.text}</p>
+          {/if}
+          <label for="experience-value" class={experience.errors.value && experience.touched.value && "text-destructive"}>Experience Value</label>
+          <input type="number" name="experience-value" placeholder="2" bind:value={experience.value} onblur={() => (experience.touched.value = true)} />
+          {#if experience.errors.value && experience.touched.value}
+            <p class="text-sm text-destructive">{experience.errors.value}</p>
+          {/if}
+        </div>
+      {/each}
+      <button class="add-button" onclick={addExperience}>Add Experience</button>
+    </div>
+
+    <!-- Features -->
+    <hr class="dht-form-divider" />
+    <h4 class="dht-form-section-heading">Features</h4>
+
+    <div class="form-group">
+      <p class="text-xs text-muted-foreground">
+        These are the adversary's features.
+      </p>
+      {#each features as feature}
+        <div class="sub-group">
+          <div class="added-button">
+            <label for="feature-name" class={feature.errors.name && feature.touched.name && "text-destructive"}>Feature Name</label>
+            <button onclick={() => {
+              features.remove(feature);
+            }}>X</button>
+          </div>
+          <input type="text" name="feature-name" placeholder="Feature name here" bind:value={feature.name} onblur={() => (feature.touched.name = true)} />
+          <label for="feature-text" class={feature.errors.text && feature.touched.text && "text-destructive"}>Feature Text</label>
+          <textarea name="feature-text" placeholder="Feature text here" class="resize-none" bind:value={feature.text} onblur={() => (feature.touched.text = true)}></textarea>
+          {#if feature.errors.name && feature.touched.name}
+            <p class="text-sm text-destructive">{feature.errors.name}</p>
+          {/if}
+          {#if feature.errors.text && feature.touched.text}
+            <p class="text-sm text-destructive">{feature.errors.text}</p>
+          {/if}
+        </div>
+      {/each}
+      <button class="add-button" onclick={addFeature}>Add Feature</button>
+    </div>
+
+    <button type="submit" onclick={onSubmit} disabled={hasErrors}>Submit</button>
 </div>

--- a/src/view/EnvironmentForm.svelte
+++ b/src/view/EnvironmentForm.svelte
@@ -32,7 +32,7 @@
       console.log("setting id", id);
       environment.id = id;
     }
-    
+
     let environmentState = $state(environment);
 
     export interface EnvironmentErrorProps {
@@ -46,6 +46,7 @@
     };
 
     let errors: EnvironmentErrorProps = $state({})
+    let touched: Partial<Record<keyof EnvironmentErrorProps, boolean>> = $state({});
 
     let environmentTypes: string[] = [
       "Event",
@@ -55,7 +56,7 @@
     ];
 
     _plugin.set(plugin);
-    
+
     $effect(() => {
       if (update) {
         if (required(environmentState.name)) {
@@ -99,12 +100,16 @@
       }
     });
 
-    let features: { 
+    let features: {
       name?: string,
       text?: string,
       errors: {
         name?: string
         text?: string,
+      },
+      touched: {
+        name?: boolean,
+        text?: boolean,
       }
     }[] = $state([]);
 
@@ -113,7 +118,8 @@
         features.push({
           name: feat.name,
           text: feat.text,
-          errors: {}
+          errors: {},
+          touched: {}
         });
       })
     }
@@ -122,7 +128,8 @@
       features.push({
         name: "",
         text: "",
-        errors: {}
+        errors: {},
+        touched: {}
       })
     }
 
@@ -158,7 +165,7 @@
         }
     }
 
-    const valid = $derived.by(() => {
+    const hasErrors = $derived.by(() => {
       return Object.values(errors).some(val => typeof val === 'string');
     })
 
@@ -180,9 +187,9 @@
     placeholder?: string
   })}
     <div class="form-group">
-      <label for={label} class={errors[errorKey] && "text-destructive"}>{label}</label>
-      <input {type} id={label} name={label} {placeholder} bind:value={environmentState[value]} />
-      {#if errors[errorKey]}
+      <label for={label} class={errors[errorKey] && touched[errorKey] && "text-destructive"}>{label}</label>
+      <input {type} id={label} name={label} {placeholder} bind:value={environmentState[value]} onblur={() => (touched[errorKey] = true)} />
+      {#if errors[errorKey] && touched[errorKey]}
         <p class="text-sm text-destructive">{errors[errorKey]}</p>
       {/if}
       <p class="text-xs text-muted-foreground">
@@ -193,6 +200,7 @@
 
 <div class="dht-environment-form">
 
+    <!-- Identity -->
     {@render formInput({
       errorKey: "name",
       label: "Name",
@@ -202,16 +210,14 @@
       placeholder: "Tavern"
     })}
 
-    {#if environmentState.alias}
-      {@render formInput({
-        errorKey: "alias",
-        label: "Alias",
-        type: "text",
-        value: "alias",
-        description: "The environment's alias, used instead of name on save.",
-        placeholder: "Tim"
-      })}
-    {/if}
+    {@render formInput({
+      errorKey: "alias",
+      label: "Alias",
+      type: "text",
+      value: "alias",
+      description: "The environment's alias, used instead of name on save.",
+      placeholder: "Tim"
+    })}
 
     <div class="form-group">
       <label for="description">Description</label>
@@ -240,7 +246,11 @@
         This is the environment's potential adversaries.
       </p>
     </div>
-    
+
+    <!-- Classification -->
+    <hr class="dht-form-divider" />
+    <h4 class="dht-form-section-heading">Classification</h4>
+
     {@render formInput({
         errorKey: "tier",
         label: "Tier",
@@ -249,24 +259,36 @@
         description: "The environment's tier.",
         placeholder: "1"
       })}
-    
+
     <div class="form-group">
-      <label for="type" class={errors.environmentType && "text-destructive"}>Environment Type</label>
+      <label for="type" class={errors.environmentType && touched.environmentType && "text-destructive"}>Environment Type</label>
       <div>
-        <select bind:value={environmentState.environmentType} name="type">
+        <select bind:value={environmentState.environmentType} name="type" onblur={() => (touched.environmentType = true)}>
           {#each environmentTypes as advType}
-              <option value={advType} label={advType}></option>    
+              <option value={advType} label={advType}></option>
           {/each}
         </select>
       </div>
       <p class="text-xs text-muted-foreground">
         Select the type of environment.
       </p>
-      {#if errors.environmentType}
+      {#if errors.environmentType && touched.environmentType}
           <p class="text-sm text-destructive">{errors.environmentType}</p>
       {/if}
     </div>
 
+    {@render formInput({
+      errorKey: "source",
+      label: "Source",
+      type: "text",
+      value: "source",
+      description: "The environment's source.",
+      placeholder: "homebrew"
+    })}
+
+    <!-- Environment -->
+    <hr class="dht-form-divider" />
+    <h4 class="dht-form-section-heading">Environment</h4>
 
     <div class="form-group">
       <label for="impulses">Impulses</label>
@@ -284,31 +306,35 @@
       description: "The environment's difficulty. (empty for none, number otherwise)",
       placeholder: "-"
     })}
-    
+
+    <!-- Features -->
+    <hr class="dht-form-divider" />
+    <h4 class="dht-form-section-heading">Features</h4>
+
     <div class="form-group">
-      <label class="label-heading" for="features">Features</label>
       <p class="text-xs text-muted-foreground">
         These are the environment's features.
       </p>
       {#each features as feature}
         <div class="sub-group">
           <div class="added-button">
-            <label for="feature-name" class={feature.errors.name && "text-destructive"}>Feature Name</label>
+            <label for="feature-name" class={feature.errors.name && feature.touched.name && "text-destructive"}>Feature Name</label>
             <button onclick={() => {
               features.remove(feature);
             }}>X</button>
           </div>
-          <input type="text" name="feature-name" placeholder="Feature name here" bind:value={feature.name} />
-          <label for="feature-text" class={feature.errors.text && "text-destructive"}>Feature Text</label>
+          <input type="text" name="feature-name" placeholder="Feature name here" bind:value={feature.name} onblur={() => (feature.touched.name = true)} />
+          <label for="feature-text" class={feature.errors.text && feature.touched.text && "text-destructive"}>Feature Text</label>
           <textarea
             placeholder="Feature text here?"
             class="resize-none"
             bind:value={feature.text}
+            onblur={() => (feature.touched.text = true)}
           ></textarea>
-          {#if feature.errors.name}
+          {#if feature.errors.name && feature.touched.name}
             <p class="text-sm text-destructive">{feature.errors.name}</p>
           {/if}
-          {#if feature.errors.text}
+          {#if feature.errors.text && feature.touched.text}
             <p class="text-sm text-destructive">{feature.errors.text}</p>
           {/if}
         </div>
@@ -316,14 +342,5 @@
       <button class="add-button" onclick={addFeature}>Add Feature</button>
     </div>
 
-    {@render formInput({
-      errorKey: "source",
-      label: "Source",
-      type: "text",
-      value: "source",
-      description: "The environment's source.",
-      placeholder: "homebrew"
-    })}
-
-    <button type="submit" onclick={onSubmit} disabled={valid}>Submit</button>
+    <button type="submit" onclick={onSubmit} disabled={hasErrors}>Submit</button>
 </div>


### PR DESCRIPTION
## Summary

- **Fix typo**: "Sever Threshold" → "Severe Threshold" (label and helper text)
- **Fix alias bug**: Alias field now always renders on both forms — the `{#if alias}` guard prevented setting an alias on new adversaries/environments
- **Touched validation**: Validation errors only appear after the user leaves (blurs) a field, eliminating eager red errors on form open
- **Feature text textarea**: AdversaryForm feature text upgraded from `<input>` to `<textarea>` (EnvironmentForm already used textarea)
- **Section grouping**: Fields reorganised into named sections with dividers — Classification, Combat Stats, Attack, Experiences, Features
- **Source moved**: Source field now sits in the Classification section rather than at the bottom of the form
- **Side-by-side rows**: HP+Stress, Major+Severe Threshold, and Attack Name+Damage Value each render in a 2-column grid row
- **Rename `valid` → `hasErrors`**: Derived state rename for clarity; Submit button behaviour unchanged
- Same improvements (alias fix, touched validation, section grouping, source move) applied to EnvironmentForm

## Test plan

- [ ] Open new adversary modal — no red errors on load, Submit is disabled until required fields have valid values
- [ ] Alias field is visible and accepts input on a new adversary
- [ ] Select "Horde" type — `#/HP` field appears beneath HP in the HP+Stress row
- [ ] HP and Stress render side-by-side; Major and Severe Threshold render side-by-side; Attack Name and Damage render side-by-side
- [ ] Feature text field is a `<textarea>`, not a single-line input
- [ ] Section headings (Classification, Combat Stats, Attack, Experiences, Features) and dividers are visible
- [ ] Open an existing adversary for editing — all values pre-populate; errors only show for fields that are actually invalid
- [ ] Repeat smoke test for EnvironmentForm (alias visible, sections present, Source in Classification)
- [ ] `npm run build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)